### PR TITLE
Replace scipy.misc.comb with scipy.special.comb.

### DIFF
--- a/cic_truncation_calc.py
+++ b/cic_truncation_calc.py
@@ -7,7 +7,7 @@
 # https://www.dsprelated.com/showcode/269.php
 
 import numpy as np
-from scipy.misc import comb as ncr
+from scipy.special import comb as ncr
 
 N = 3
 R = 16


### PR DESCRIPTION
The old function was deprecated in scipy 1.0.0 [1], and is gone in
current scipy releases (1.5.2 here.). I'm a little confused since you're
using Python 3.6+ which would ordinarily suggest a much newer scipy
release.

[1]: https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.comb.html